### PR TITLE
Review Updates: Tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ python:
 sudo: 'required'
 
 
+before_install:
+  - 'echo "nameserver 8.8.8.8" | sudo -EH tee -a /etc/resolvconf/resolv.conf.d/tail > /dev/null'
+  - 'echo "nameserver 8.8.4.4" | sudo -EH tee -a /etc/resolvconf/resolv.conf.d/tail > /dev/null'
+  - 'sudo -EH resolvconf -u'
+
 install:
   # Install test requirements
   - 'pip install -r requirements-devel.txt'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,4 +8,4 @@ midonet_agent_cluster_project: 'service'
 midonet_agent_cluster_password: 'midonet_default_pass'
 midonet_agent_cluster_port: 8181
 midonet_agent_agent_template: 'agent-compute-medium'
-midonet_agent_max_heap_size: '2048M'
+midonet_agent_max_heap_size: '512M'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,5 @@
 
 - name: Restart midolman
   service:
-    name: midolman
+    name: 'midolman'
     state: restarted

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -2,29 +2,31 @@
 
 - name: Basic midolman.conf
   template:
-    src: midolman.conf.j2
-    dest: /etc/midolman/midolman.conf
-    owner: root
-    group: root
+    src: 'midolman.conf.j2'
+    dest: '/etc/midolman/midolman.conf'
+    owner: 'root'
+    group: 'root'
+  notify: Restart midolman
 
 - name: Apply host template (this node only)
-  shell: mn-conf template-set -h local -t "{{ midonet_agent_agent_template }}"
+  shell: 'mn-conf template-set -h local -t "{{ midonet_agent_agent_template }}"'
   changed_when: False
-  retries: 5
   delay: 10
+  register: midonet_agent_mn_conf_template_set
+  retries: 5
+  until: midonet_agent_mn_conf_template_set|success
 
 - name: Configure MAX_HEAP_SIZE for JVM
   lineinfile:
-    dest: /etc/midolman/midolman-env.sh
-    regexp: ^MAX_HEAP_SIZE=
-    line: MAX_HEAP_SIZE="{{ midonet_agent_max_heap_size }}"
+    dest: '/etc/midolman/midolman-env.sh'
+    regexp: '^MAX_HEAP_SIZE='
+    line: 'MAX_HEAP_SIZE="{{ midonet_agent_max_heap_size }}"'
     state: present
+  notify: Restart midolman
 
 - name: Create midonetrc
   template:
-    src: midonetrc.j2
-    dest: /root/.midonetrc
-    owner: root
-    group: root
-  notify:
-    - Restart midolman
+    src: 'midonetrc.j2'
+    dest: '/root/.midonetrc'
+    owner: 'root'
+    group: 'root'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,20 @@
 ---
 
-- meta: flush_handlers
 - include: packages_redhat.yml
   when: ansible_os_family == 'RedHat'
+
 - include: packages_debian.yml
   when: ansible_os_family == 'Debian'
+
 - include: configuration.yml
+
+- include: services.yml
+
 - meta: flush_handlers
+
+- include: sanitycheck.yml
+
 - include: tunnel-zone.yml
-  when: midonet_agent_tzone_name is defined and midonet_agent_tzone_type is defined
+  when:
+    - midonet_agent_tzone_name is defined
+    - midonet_agent_tzone_type is defined

--- a/tasks/packages_debian.yml
+++ b/tasks/packages_debian.yml
@@ -1,17 +1,10 @@
 ---
 
-- name: Install PPA for Java8
-  apt_repository:
-    repo: 'ppa:openjdk-r'
-
 - name: Install Midolman
   apt:
-    name: midolman
-    state: latest
-    install_recommends: False
-    update_cache: yes
-
-- name: Install midonet client
-  apt:
-    name: python-midonetclient
+    name: '{{ item }}'
     state: present
+  with_items:
+    - 'midolman'
+    - 'netcat-openbsd'
+    - 'python-midonetclient'

--- a/tasks/packages_redhat.yml
+++ b/tasks/packages_redhat.yml
@@ -5,5 +5,6 @@
     name: '{{ item }}'
     state: present
   with_items:
-    - midolman
-    - python-midonetclient
+    - 'midolman'
+    - 'nmap-ncat'
+    - 'python-midonetclient'

--- a/tasks/sanitycheck.yml
+++ b/tasks/sanitycheck.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Make sure that midolman is alive
+  command: 'nc -U /var/run/midolman/midolman.sock'
+  always_run: True
+  changed_when: False
+  delay: 10
+  register: midonet_agent_netcat_sock
+  retries: 18
+  until: midonet_agent_netcat_sock|success

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Start and enable midolman
+  service:
+    enabled: True
+    name: 'midolman'
+    state: started

--- a/tasks/tunnel-zone.yml
+++ b/tasks/tunnel-zone.yml
@@ -1,32 +1,32 @@
 ---
 
 - name: Check if tunnel zone exists
-  shell: "midonet-cli -e tunnel-zone list | grep {{ midonet_agent_tzone_name }}"
-  register: midonet_tzone_exists
+  shell: 'midonet-cli -e tunnel-zone list | grep {{ midonet_agent_tzone_name }}'
   failed_when: midonet_tzone_exists.rc >= 2
+  register: midonet_tzone_exists
 
 - name: Create tunnel zone
-  shell: "midonet-cli -e tunnel-zone create name {{ midonet_agent_tzone_name }} type {{ midonet_agent_tzone_type }} "
+  shell: 'midonet-cli -e tunnel-zone create name {{ midonet_agent_tzone_name }} type {{ midonet_agent_tzone_type }} '
   when: midonet_tzone_exists | failed
 
 - name: Get tunnel zone id
-  shell: "midonet-cli -e tunnel-zone list | grep {{ midonet_agent_tzone_name }} | cut -d ' ' -f 2"
+  shell: 'midonet-cli -e tunnel-zone list | grep {{ midonet_agent_tzone_name }} | cut -d " " -f 2'
   register: midonet_tzone
 
 - name: Get host id
-  shell: "midonet-cli -e host list | grep {{ ansible_hostname }} | cut -d ' ' -f 2"
+  shell: 'midonet-cli -e host list | grep {{ ansible_hostname }} | cut -d " " -f 2'
   register: midonet_hostid
-  until: midonet_hostid.stdout != ""
+  until: midonet_hostid.stdout != ''
   retries: 5
   delay: 10
 
 - name: Check if host is already in tunnel zone
-  shell: "midonet-cli -e tunnel-zone {{ midonet_tzone.stdout }} list member | grep {{ midonet_hostid.stdout }}"
+  shell: 'midonet-cli -e tunnel-zone {{ midonet_tzone.stdout }} list member | grep {{ midonet_hostid.stdout }}'
   register: midonet_tzone_member_exists
   failed_when: midonet_tzone_member_exists.rc >= 2
 
 - name: Add host to tunnel zone
-  shell: "midonet-cli -e tunnel-zone {{ midonet_tzone.stdout }} add member host {{ midonet_hostid.stdout }} address {{ midonet_agent_tunnel_ip }}"
+  shell: 'midonet-cli -e tunnel-zone {{ midonet_tzone.stdout }} add member host {{ midonet_hostid.stdout }} address {{ midonet_agent_tunnel_ip }}'
   when:
     - midonet_tzone_member_exists | failed
   retries: 5

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -29,7 +29,7 @@ end
 
 def set_hardware(config, provider)
   config.vm.provider provider do |machine|
-    machine.memory = 2048
+    machine.memory = 3072
     machine.cpus = 1
   end
 end

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -8,3 +8,6 @@
 
 - name: 'cassandra'
   src: 'https://github.com/midonet/ansible-cassandra'
+
+- name: 'midonet-cluster'
+  src: 'https://github.com/midonet/ansible-midonet-cluster'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -14,19 +14,16 @@
       cassandra_hosts:
         - '{{ inventory_hostname }}'
 
-    - role: ansible-midonet-agent
+    - role: midonet-cluster
       zookeeper_hosts:
         - '{{ inventory_hostname }}'
       cassandra_hosts:
         - '{{ inventory_hostname }}'
       midonet_cluster_max_heap_size: "512M"
 
-  post_tasks:
-    - name: Check java and midolman processes are running
-      shell: ps auxf | grep {{ item }}
-      register: command_result
-      failed_when: "'{{ item }}' not in command_result.stdout"
-      changed_when: False
-      with_items:
-        - java
-        - midolman
+    - role: ansible-midonet-agent
+      zookeeper_hosts:
+        - '{{ inventory_hostname }}'
+      cassandra_hosts:
+        - '{{ inventory_hostname }}'
+      midonet_agent_max_heap_size: "512M"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for midonet-agent


### PR DESCRIPTION
Review updates regarding tasks, namely:
- Modify the Travis CI worker VM to use `8.8.8.8` and `8.8.4.4`
  in addition to `169.254.169.254` for name resolution, because
  `169.254.169.254` will not be usable after midolman starts working
  (because it collides with the metadata IP).
- Decrease the heap size for `midolman` when testing, because default 2G
  is too much for some test system.
- `register` task result and specify `until` condition, which is
  required for `retries` to actually function.
- Invoke handler to restart `midolman` after modifying configuration
  files (and removing invocation where it is not needed).
- Add sanity check, checking that UNIX domain socket
  `/var/run/midolman/midolman.sock` is accessible.
- Start and enable `midolman` service.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
